### PR TITLE
fixed collisions with different masses

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -13,13 +13,11 @@ int main() {
   // this is mac versioning add other versions
   const char *glsl_version = "#version 150";
   ImVec4 clear_color = ImVec4(0.0f, 0.0f, 0.0f, 1.00f);
-  uint width = 1280;
-  uint height = 720;
+  uint32_t width = 1280;
+  uint32_t height = 720;
 
   auto main_view = MainView(glsl_version, clear_color, width, height);
   main_view.createWindow();
-
-  // auto start = std::chrono::system_clock::now();
 
   auto statsModal = ViewStats();
   auto objectConfigModal = ViewObjectsConfig();
@@ -53,13 +51,6 @@ int main() {
 
       frame_time -= dt;
     }
-
-    // auto current = std::chrono::system_clock::now();
-    // std::chrono::duration<double> duration = current - start;
-    // if (duration.count() > 0.5) {
-    //   SystemState::AddObject(new CircleObject(1.0f, 0, 0, 5.0f));
-    //   start = current;
-    // }
 
     SystemState::Draw();
     main_view.render();

--- a/physics/systemState.cpp
+++ b/physics/systemState.cpp
@@ -133,27 +133,32 @@ void SystemState::ResolveCircleCollision(CircleObject *circle_1,
     const ImVec2 circle_1_vec = circle_1->getVelocity();
     const ImVec2 circle_2_vec = circle_2->getVelocity();
 
+    const float tangent_x = -1.0f * y_vector;
+    const float tangent_y = x_vector;
+
+    const float dp_tan_1 =
+        circle_1_vec.x * tangent_x + circle_1_vec.y * tangent_y;
+    const float dp_tan_2 =
+        circle_2_vec.x * tangent_x + circle_2_vec.y * tangent_y;
+
     // dot product normal
-    float dp_num_1 = circle_1_vec.x * x_vector + circle_1_vec.y * y_vector;
-    float dp_num_2 = circle_2_vec.x * x_vector + circle_2_vec.y * y_vector;
+    const float dp_num_1 =
+        circle_1_vec.x * x_vector + circle_1_vec.y * y_vector;
+    const float dp_num_2 =
+        circle_2_vec.x * x_vector + circle_2_vec.y * y_vector;
 
-    const float new_vel_1_x =
-        (circle_1_vec.x * (circle_1->getMass() - circle_2->getMass()) +
-         (2 * circle_2->getMass() * circle_2_vec.x)) /
-        (circle_1->getMass() + circle_2->getMass());
-    const float new_vel_1_y =
-        (circle_1_vec.y * (circle_1->getMass() - circle_2->getMass()) +
-         (2 * circle_2->getMass() * circle_2_vec.y)) /
-        (circle_1->getMass() + circle_2->getMass());
+    const float m1 = (dp_num_1 * (circle_1->getMass() - circle_2->getMass()) +
+                      (2.0f * circle_2->getMass() * dp_num_2)) /
+                     (circle_1->getMass() + circle_2->getMass());
+    const float m2 = (dp_num_2 * (circle_2->getMass() - circle_1->getMass()) +
+                      (2.0f * circle_1->getMass() * dp_num_1)) /
+                     (circle_1->getMass() + circle_2->getMass());
 
-    const float new_vel_2_x =
-        (circle_2_vec.x * (circle_2->getMass() - circle_1->getMass()) +
-         (2 * circle_1->getMass() * circle_1_vec.x)) /
-        (circle_1->getMass() + circle_2->getMass());
-    const float new_vel_2_y =
-        (circle_2_vec.y * (circle_2->getMass() - circle_1->getMass()) +
-         (2 * circle_1->getMass() * circle_1_vec.y)) /
-        (circle_1->getMass() + circle_2->getMass());
+    const float new_vel_1_x = tangent_x * dp_tan_1 + x_vector * m1;
+    const float new_vel_1_y = tangent_y * dp_tan_1 + y_vector * m1;
+
+    const float new_vel_2_x = tangent_x * dp_tan_2 + x_vector * m2;
+    const float new_vel_2_y = tangent_y * dp_tan_2 + y_vector * m2;
 
     circle_1->setVelocity(ImVec2(new_vel_1_x, new_vel_1_y));
     circle_2->setVelocity(ImVec2(new_vel_2_x, new_vel_2_y));

--- a/physics/systemState.cpp
+++ b/physics/systemState.cpp
@@ -134,7 +134,6 @@ void SystemState::ResolveCircleCollision(CircleObject *circle_1,
     const ImVec2 circle_2_vec = circle_2->getVelocity();
 
     // dot product normal
-
     float dp_num_1 = circle_1_vec.x * x_vector + circle_1_vec.y * y_vector;
     float dp_num_2 = circle_2_vec.x * x_vector + circle_2_vec.y * y_vector;
 

--- a/physics/systemState.cpp
+++ b/physics/systemState.cpp
@@ -136,6 +136,7 @@ void SystemState::ResolveCircleCollision(CircleObject *circle_1,
     const float tangent_x = -1.0f * y_vector;
     const float tangent_y = x_vector;
 
+    // dot product tangent
     const float dp_tan_1 =
         circle_1_vec.x * tangent_x + circle_1_vec.y * tangent_y;
     const float dp_tan_2 =

--- a/physics/systemState.cpp
+++ b/physics/systemState.cpp
@@ -133,21 +133,28 @@ void SystemState::ResolveCircleCollision(CircleObject *circle_1,
     const ImVec2 circle_1_vec = circle_1->getVelocity();
     const ImVec2 circle_2_vec = circle_2->getVelocity();
 
-    const float impulse =
-        2 *
-        (circle_1_vec.x * x_vector + circle_1_vec.y * y_vector -
-         circle_2_vec.x * x_vector - circle_2_vec.y * y_vector) /
-        (circle_1->getMass() + circle_2->getMass());
+    // dot product normal
+
+    float dp_num_1 = circle_1_vec.x * x_vector + circle_1_vec.y * y_vector;
+    float dp_num_2 = circle_2_vec.x * x_vector + circle_2_vec.y * y_vector;
 
     const float new_vel_1_x =
-        circle_1_vec.x - impulse * circle_1->getMass() * x_vector;
+        (circle_1_vec.x * (circle_1->getMass() - circle_2->getMass()) +
+         (2 * circle_2->getMass() * circle_2_vec.x)) /
+        (circle_1->getMass() + circle_2->getMass());
     const float new_vel_1_y =
-        circle_1_vec.y - impulse * circle_1->getMass() * y_vector;
+        (circle_1_vec.y * (circle_1->getMass() - circle_2->getMass()) +
+         (2 * circle_2->getMass() * circle_2_vec.y)) /
+        (circle_1->getMass() + circle_2->getMass());
 
     const float new_vel_2_x =
-        circle_2_vec.x + impulse * circle_2->getMass() * x_vector;
+        (circle_2_vec.x * (circle_2->getMass() - circle_1->getMass()) +
+         (2 * circle_1->getMass() * circle_1_vec.x)) /
+        (circle_1->getMass() + circle_2->getMass());
     const float new_vel_2_y =
-        circle_2_vec.y + impulse * circle_2->getMass() * y_vector;
+        (circle_2_vec.y * (circle_2->getMass() - circle_1->getMass()) +
+         (2 * circle_1->getMass() * circle_1_vec.y)) /
+        (circle_1->getMass() + circle_2->getMass());
 
     circle_1->setVelocity(ImVec2(new_vel_1_x, new_vel_1_y));
     circle_2->setVelocity(ImVec2(new_vel_2_x, new_vel_2_y));


### PR DESCRIPTION
Dynamic collisions was not accounting for different masses, so lower masses had a bigger "push" than higher masses resulting in 1/2(m*v^2)  "impulse" was not being maintained

Solved using this https://en.wikipedia.org/wiki/Elastic_collision#One-dimensional_relativistic